### PR TITLE
Fixed install-binary.sh when wget is used

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -74,7 +74,7 @@ getDownloadURL() {
   if type "curl" >/dev/null 2>&1; then
     DOWNLOAD_URL=$(curl -s $latest_url | grep $OS | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
   elif type "wget" >/dev/null 2>&1; then
-    DOWNLOAD_URL=$(wget -q -O - $latest_url | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
+    DOWNLOAD_URL=$(wget -q -O - $latest_url | grep $OS | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
   fi
 }
 


### PR DESCRIPTION
Install failed on a system without curl, since the wget command used to retrieve latest version doesn't grep for the detected OS, and so returns a URL for every available OS, which subsequently causes wget to fail.

This patch corrects this issue :)