### PR TITLE
Documenting how path elements containing dots may be asserted

### DIFF
--- a/DOCUMENT.md
+++ b/DOCUMENT.md
@@ -98,6 +98,14 @@ The assertion is defined with the assertion type as the key and its parameters a
 
 - **documentIndex**: *int, optional*. The index of rendered documents (devided by `---`) to be asserted, default to 0. Generally you can ignored this field if the template file render only one document.
 
+Map keys in `path` containing periods (`.`) are supported with the use of backslashes:
+
+```yaml
+      - equal:
+          path: metadata.annotations.kubernetes\.io/ingress\.class
+          value: nginx
+```
+
 ### Assertion Types
 
 Available assertion types are listed below:

--- a/unittest/valueutils/valueutils_test.go
+++ b/unittest/valueutils/valueutils_test.go
@@ -12,7 +12,8 @@ func TestGetValueOfSetPath(t *testing.T) {
 	a := assert.New(t)
 	data := common.K8sManifest{
 		"a": map[interface{}]interface{}{
-			"b": []interface{}{"_", map[interface{}]interface{}{"c": "yes"}},
+			"b":   []interface{}{"_", map[interface{}]interface{}{"c": "yes"}},
+			"x.y": "ok",
 		},
 	}
 
@@ -20,6 +21,7 @@ func TestGetValueOfSetPath(t *testing.T) {
 		"a.b[1].c": "yes",
 		"a.b[0]":   "_",
 		"a.b":      []interface{}{"_", map[interface{}]interface{}{"c": "yes"}},
+		"a.x\\.y":  "ok",
 	}
 
 	for path, expect := range expectionsMapping {


### PR DESCRIPTION
@cb-jeffduska ran into this case and the documentation was unclear on what syntax to use. (My first guess was `outer['inner.key']` which did not work.)