### PR TITLE
Small fixes for helm3

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -5,15 +5,15 @@
 PROJECT_NAME="helm-unittest"
 PROJECT_GH="lrills/$PROJECT_NAME"
 
-: ${HELM_PLUGIN_PATH:="$(helm home)/plugins/helm-unittest"}
+#: ${HELM_PLUGIN_PATH:="$(helm home)/plugins/helm-unittest"}
 
 # Convert the HELM_PLUGIN_PATH to unix if cygpath is
 # available. This is the case when using MSYS2 or Cygwin
 # on Windows where helm returns a Windows path but we
 # need a Unix path
-if type cygpath &> /dev/null; then
-  HELM_PLUGIN_PATH=$(cygpath -u $HELM_PLUGIN_PATH)
-fi
+#if type cygpath &> /dev/null; then
+#  HELM_PLUGIN_PATH=$(cygpath -u $HELM_PLUGIN_PATH)
+#fi
 
 if [[ $SKIP_BIN_INSTALL == "1" ]]; then
   echo "Skipping binary install"
@@ -97,10 +97,10 @@ installFile() {
   mkdir -p "$HELM_TMP"
   tar xf "$PLUGIN_TMP_FILE" -C "$HELM_TMP"
   HELM_TMP_BIN="$HELM_TMP/untt"
-  echo "Preparing to install into ${HELM_PLUGIN_PATH}"
+  echo "Preparing to install into ${HELM_PLUGIN_DIR}"
   # Use * to also copy the file withe the exe suffix on Windows
-  cp "$HELM_TMP_BIN"* "$HELM_PLUGIN_PATH"
-  echo "$PROJECT_NAME installed into $HELM_PLUGIN_PATH"
+  cp "$HELM_TMP_BIN"* "$HELM_PLUGIN_DIR"
+  echo "$PROJECT_NAME installed into $HELM_PLUGIN_DIR"
 }
 
 # fail_trap is executed if an error occurs.
@@ -117,7 +117,7 @@ fail_trap() {
 testVersion() {
   # To avoid to keep track of the Windows suffix,
   # call the plugin assuming it is in the PATH
-  PATH=$PATH:$HELM_PLUGIN_PATH
+  PATH=$PATH:$HELM_PLUGIN_DIR
   untt -h
 }
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,5 +5,5 @@ description: "Unit test for helm chart in YAML with ease to keep your chart func
 ignoreFlags: false
 command: "$HELM_PLUGIN_DIR/untt"
 hooks:
-  install: "$HELM_PLUGIN_DIR/install-binary.sh"
-  update: "$HELM_PLUGIN_DIR/install-binary.sh"
+  install: "cd $HELM_PLUGIN_DIR; $HELM_PLUGIN_DIR/install-binary.sh"
+  update: "cd $HELM_PLUGIN_DIR; $HELM_PLUGIN_DIR/install-binary.sh"


### PR DESCRIPTION
Hi !

Small fixes for helm3, replace HELM_PLUGIN_PATH with HELM_PLUGIN_DIR.

`helm home` removed from helm3. This PR probably needs review.

I did not check compatibility with helm2

https://github.com/lrills/helm-unittest/issues/87