### PR TITLE
fix: install script for Helm v3 compatibility

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -135,6 +135,20 @@
   version = "v1.0"
 
 [[projects]]
+  digest = "1:a83f443aa94120996b96c5d94a1eb92aa8da8795f418edcb7f92c0148a2358a9"
+  name = "github.com/lrills/helm-unittest"
+  packages = [
+    "unittest",
+    "unittest/common",
+    "unittest/snapshot",
+    "unittest/validators",
+    "unittest/valueutils",
+  ]
+  pruneopts = ""
+  revision = "695dac23a25c1e39836cf3c8273fab6baa924f69"
+  version = "v0.1.5"
+
+[[projects]]
   digest = "1:9ea83adf8e96d6304f394d40436f2eb44c1dc3250d223b74088cc253a6cd0a1c"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
@@ -267,6 +281,11 @@
   input-imports = [
     "github.com/bradleyjkemp/cupaloy",
     "github.com/fatih/color",
+    "github.com/lrills/helm-unittest/unittest",
+    "github.com/lrills/helm-unittest/unittest/common",
+    "github.com/lrills/helm-unittest/unittest/snapshot",
+    "github.com/lrills/helm-unittest/unittest/validators",
+    "github.com/lrills/helm-unittest/unittest/valueutils",
     "github.com/mitchellh/mapstructure",
     "github.com/pmezard/go-difflib/difflib",
     "github.com/spf13/cobra",

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -5,7 +5,13 @@
 PROJECT_NAME="helm-unittest"
 PROJECT_GH="lrills/$PROJECT_NAME"
 
-: ${HELM_PLUGIN_PATH:="$(helm home)/plugins/helm-unittest"}
+if [[ $(helm version | grep v3) ]]; then
+  HELM_PATH="$(helm env | grep HELM_PLUGINS | awk -F '=' '{print $2}' | sed 's/\"//g')"
+else
+  HELM_PATH="$(helm home)"
+fi
+
+: ${HELM_PLUGIN_PATH:="$HELM_PATH/helm-unittest"}
 
 # Convert the HELM_PLUGIN_PATH to unix if cygpath is
 # available. This is the case when using MSYS2 or Cygwin

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "unittest"
-version: "0.1.5"
+version: "0.1.6"
 usage: "unittest for helm charts"
 description: "Unit test for helm chart in YAML with ease to keep your chart functional and robust."
 ignoreFlags: false


### PR DESCRIPTION
# Helm 3 Install

## Why?
In the Helm V3 installation, the `home` command for helm is not available anymore.

## What?
Added a way to detect the helm version and execute the corresponding command to install it