### PR TITLE
fix issue with 'helm home' command which breaks on helm3 and minor adjustments

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -5,14 +5,12 @@
 PROJECT_NAME="helm-unittest"
 PROJECT_GH="lrills/$PROJECT_NAME"
 
-: ${HELM_PLUGIN_PATH:="$(helm home)/plugins/helm-unittest"}
-
 # Convert the HELM_PLUGIN_PATH to unix if cygpath is
 # available. This is the case when using MSYS2 or Cygwin
 # on Windows where helm returns a Windows path but we
 # need a Unix path
 if type cygpath &> /dev/null; then
-  HELM_PLUGIN_PATH=$(cygpath -u $HELM_PLUGIN_PATH)
+  HELM_PLUGIN_PATH=$(cygpath -u $HELM_PLUGIN_DIR)
 fi
 
 if [[ $SKIP_BIN_INSTALL == "1" ]]; then
@@ -97,10 +95,10 @@ installFile() {
   mkdir -p "$HELM_TMP"
   tar xf "$PLUGIN_TMP_FILE" -C "$HELM_TMP"
   HELM_TMP_BIN="$HELM_TMP/untt"
-  echo "Preparing to install into ${HELM_PLUGIN_PATH}"
+  echo "Preparing to install into ${HELM_PLUGIN_DIR}"
   # Use * to also copy the file withe the exe suffix on Windows
-  cp "$HELM_TMP_BIN"* "$HELM_PLUGIN_PATH"
-  echo "$PROJECT_NAME installed into $HELM_PLUGIN_PATH"
+  cp "$HELM_TMP_BIN"* "$HELM_PLUGIN_DIR"
+  echo "$PROJECT_NAME installed into $HELM_PLUGIN_DIR"
 }
 
 # fail_trap is executed if an error occurs.
@@ -117,8 +115,8 @@ fail_trap() {
 testVersion() {
   # To avoid to keep track of the Windows suffix,
   # call the plugin assuming it is in the PATH
-  PATH=$PATH:$HELM_PLUGIN_PATH
-  untt -h
+  PATH=$PATH:$HELM_PLUGIN_DIR
+  untt -h >/dev/null 2&>1
 }
 
 # Execution


### PR DESCRIPTION
[CHANGE]
* Usage of command: `helm home` breaks on helm3 due to moving to [XDG Base Directory Specifications](https://helm.sh/docs/faq/) - Changed installation path to $HELM_PLUGINS_DIR which works both on helm2/3 
* Redirected output of test command into `/dev/null` in order to have a cleaner installation experience

```
Downloading https://github.com/lrills/helm-unittest/releases/download/v0.1.5/helm-unittest-linux-0.1.5.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   620  100   620    0     0    718      0 --:--:-- --:--:-- --:--:--   717
100 3105k  100 3105k    0     0   698k      0  0:00:04  0:00:04 --:--:-- 1038k
Preparing to install into /root/.helm/plugins/helm-unittest
helm-unittest installed into /root/.helm/plugins/helm-unittest
Installed plugin: unittest
```